### PR TITLE
Make dependencies available in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "Nikos Vasileiou",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "@babel/core": "^7.7.2",
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.0",


### PR DESCRIPTION
CI needs the dependencies to build assets in production. Let's change it for all of them and figure this out later.